### PR TITLE
Remove [yzqzss`s FreshRSS free server]

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,6 @@ Inspired by [Awesome lists](https://github.com/sindresorhus/awesome) and [@realS
 
 ### FreshRSS
 
-- https://rss.othing.xyz/ by [yzqzss | 一座桥在水上](https://blog.othing.xyz) <sup>[518](https://t.me/s/aboutrss/518)</sup> ![Website](https://img.shields.io/website?down_message=down&up_message=up&url=https%3A%2F%2Frss.othing.xyz%2F) (Invitation required)
 - https://rss.alex0.dev by [Alex Kuang](https://alex0.dev/blog/web/self-hosted-freshrss-open-registration/) ![Website](https://img.shields.io/website?down_message=down&up_message=up&url=https%3A%2F%2Frss.alex0.dev%2F) (user:demo passwd:freshdemo)
 - http://freshrss.fanfpy.top/ by [fanfpy](https://fanfpy.top/) <sup>[1074](https://t.me/s/aboutrss/1074)</sup> ![Website](https://img.shields.io/website?down_message=down&up_message=up&url=http%3A%2F%2Ffreshrss.fanfpy.top%2F)
 - http://rss.iridium.cyou/ by [IRIDIUM](https://docs.iridium.cyou/) ![Website](https://img.shields.io/website?down_message=down&up_message=up&url=http%3A%2F%2Frss.iridium.cyou%2F)


### PR DESCRIPTION
之前只有我一个在提供 FreshRSS 实例，现在两年多了，目前 ALL-about-RSS List 上有4位同热爱RSS的爱好者（Alex Kuang、fanfpy、IRIDIUM、逍遥隐士）在提供免费FreshRSS实例，还都是国内的爱好者，我挺开心的。

我一开始只是觉得部分免费的在线RSS订阅服务要FQ，还限制订阅源数量；他们的付费方案价格还贼贵，于是就自建了个FreshRSS站（TTRSS的坑太多，用过的人都懂，所以我选择了FreshRSS） ，后来觉得自用有点闲置服务器资源，也就开放注册了。

我几个月前就关闭了注册，只接受邀请注册，主要原因还是降低域名被Ban的风险，因为现在 othing.xyz 这个域名用这么久了，不想换，有些重要的东西依赖于这个域名，想一直用下去。毕竟这几年国内RSS界的风头太和谐了......哎，我真胆小。

对于已注册本站的用户，本站会一直运营下去，直到FreshRSS本身不再维护了，毕竟我也要自用。

不过我还是挺高兴的，前一两年，我可能是全球唯一一个提供免费公开FreshRSS实例的人，哈哈。肯定有人是因为在 ALL-about-RSS 仓库看有什么TTRSS服务的实例~~可以白嫖~~的时候，发现了FreshRSS，试用发现还行，就一直用了下去。
现在再看这张表，只有2个站还在开放TTRSS的注册（都是国内的），而开放注册的FreshRSS实例却有4个（也都是国内的）！

XXZH，KYLY！

----yzqzss | 一座桥在水上