### PR TITLE
update info

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,7 +858,7 @@ Inspired by [Awesome lists](https://github.com/sindresorhus/awesome) and [@realS
 - [OneUp](https://oneupapp.io) <sup>[646](https://t.me/s/aboutrss/646)</sup>
 - [feedpushr](https://github.com/ncarlier/feedpushr) <sup>[692](https://t.me/s/aboutrss/692)</sup> [![Open-Source Software][oss icon]](https://github.com/ncarlier/feedpushr)
 - [Pipethru](https://www.pipethru.com/)
-- [Automate.io](https://automate.io/)
+- [~~Automate.io~~](https://automate.io/)
 - [Actionsflow](https://actionsflow.github.io/) <sup>[956](https://t.me/s/aboutrss/956)</sup> [![Open-Source Software][oss icon]](https://github.com/actionsflow/actionsflow)
 - [integrately](https://integrately.com/) <sup>[1114](https://t.me/s/aboutrss/1114)</sup>
 


### PR DESCRIPTION
Automate.io was acquired by Notion and closed down.