### PR TITLE
Greasemonkey Newspaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1582,6 +1582,7 @@ Inspired by [Awesome lists](https://github.com/sindresorhus/awesome) and [@realS
 
 ### RSS Feed Finding/Detection
 
+- [Newspaper](https://greasyfork.org/scripts/465932-newspaper-syndication-feed-reader) [![][Greasemonkey icon]]
 - [RSSHub Radar](https://diygod.me/rsshub-radar/) <sup>[47](https://t.me/s/aboutrss/47), [116](https://t.me/s/aboutrss/116)</sup> [![][Chrome icon]](https://chrome.google.com/webstore/detail/kefjpfngnndepjbopdmoebkipbgkggaa)[![Firefox][Firefox icon]](https://addons.mozilla.org/zh-CN/firefox/addon/rsshub-radar/)[![Windows][Windows icon]](https://microsoftedge.microsoft.com/addons/detail/gangkeiaobmjcjokiofpkfpcobpbmnln)[![Open-Source Software][oss icon]](https://github.com/DIYgod/RSSHub-Radar)
 - [Easy to RSS](https://idealclover.top/projects.html) [![][Chrome icon]](https://chrome.google.com/webstore/detail/easy-to-rss/hbcmpkcpbnecinpngdnfbnknfkdpdfli)[![Firefox][Firefox icon]](https://addons.mozilla.org/zh-CN/firefox/addon/easy-to-rss/)[![Open-Source Software][oss icon]](https://github.com/idealclover/easy-to-rss)
 - [RSS+](https://greasyfork.org/scripts/373252-rss-show-site-all-rss)


### PR DESCRIPTION
Newspaper is a one-of-a-kind RSS viewer which is enturely made of ECMAScript (JavaScript), and is available for Greasemonkey; therefore it is available also for browsers that do not support UXP (Unified XUL Platform) or, the so-called, WebExtension.