### PR TITLE
Add NebulaPicker to RSS Feed Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,6 +990,7 @@ Inspired by [Awesome lists](https://github.com/sindresorhus/awesome) and [@realS
 - [RSS Worker](https://github.com/yllhwa/RSSWorker) <sup>[1379](https://t.me/s/aboutrss/1379)</sup> [![Open-Source Software][oss icon]](https://github.com/yllhwa/RSSWorker)
 - [VeRSSion](https://verssion.one/) <sup>[1396](https://t.me/s/aboutrss/1396)</sup>
 - [mkfd](https://github.com/TBosak/mkfd)
+- [NebulaPicker](https://github.com/djsilva99/nebulapicker) [![Open-Source Software][oss icon]](https://github.com/djsilva99/nebulapicker)
 
 #### webpage/html
 


### PR DESCRIPTION
Hello!

I have just launched the first stable release of NebulaPicker. It is designed for users who want a self-hosted, privacy-first way to manage information overload by creating their own 'clean' RSS feeds from multiple noisy sources by applying custom keyword filters and aggregation rules.

Key Features:
- Aggregation: Combines multiple RSS sources into a single curated output.
- Automated Filtering: Uses scheduled CRON jobs to apply user-defined rules (keyword matching/exclusion).
- Privacy-Focused: Entirely self-hosted, giving users full control over their data.
- Two Editions: An Original version for lightweight filtering and a Content Extractor version that integrates with Wallabag for full-text archival.

I believe this would be a valuable addition for users looking for a self-hosted alternative to commercial feed filters and aggregators.

Project Link: [https://github.com/djsilva99/nebulapicker](https://github.com/djsilva99/nebulapicker)