### PR TITLE
Add WeWantPeace - RSS-based global conflict monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,7 @@ Inspired by [Awesome lists](https://github.com/sindresorhus/awesome) and [@realS
 - [Feedspot](https://www.feedspot.com/) <sup>[530](https://t.me/s/aboutrss/530)</sup> ![Online][Online icon]
 - [Informate](https://informate.elsetech.io/) <sup>[724](https://t.me/s/aboutrss/724)</sup> ![Online][Online icon]
 - [Castbee](https://castbee.net/) <sup>[864](https://t.me/s/aboutrss/864), [883](https://t.me/s/aboutrss/883)</sup> ![Online][Online icon][![Chrome][Chrome icon]](https://chrome.google.com/webstore/detail/castbee-news-subscriber/pmggohjclghclepgangbbgakapljlnnc)
+- [WeWantPeace](https://www.wewantpeace.live) [![Open-Source Software][oss icon]](https://github.com/nameofkk/wewantpeace) - Real-time global conflict monitoring platform that aggregates 200+ RSS feeds across 195 countries with AI-powered analysis, interactive crisis map, severity scoring, and tension index tracking.
 
 ## 🛠 RSS Feed Generation
 


### PR DESCRIPTION
## Add WeWantPeace - RSS-based global conflict monitoring platform

WeWantPeace heavily relies on RSS as its primary data collection mechanism:

- **200+ RSS feeds** from major news agencies (Reuters, AP, BBC, Al Jazeera, regional outlets)
- Automated RSS collection with 3-5 minute polling cycles via Celery Beat
- AI-powered analysis pipeline: RSS collection -> normalization -> deduplication -> clustering -> scoring
- Additional sources: Telegram OSINT channels + APIs

The platform transforms raw RSS feeds into actionable conflict intelligence with severity scoring, geographic mapping, personalized impact analysis, and trend detection.

### Links
- **Live**: https://www.wewantpeace.live
- **Open methodology**: https://github.com/nameofkk/wewantpeace-methodology
- **License**: CC-BY-NC-4.0