### PR TITLE
Add Sharpe Terminal RSS to crypto feed resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1731,6 +1731,7 @@ So a new user can see something other than a wall of raw XML.  Note that XSLT is
 - [【925】位优质Mirror作者的Feed地址](https://twitter.com/zlexdl/status/1502629374889144323) <sup>[1210](https://t.me/s/aboutrss/1210)</sup> [![Open-Source Software][oss icon]](https://github.com/zlexdl/mirror)
 - [PrimitivesFeed](https://github.com/PrimitivesLane/PrimitivesFeed)  [![Open-Source Software][oss icon]](https://github.com/PrimitivesLane/PrimitivesFeed)
 - [Bitcoin RSS Feeds](https://bc1984.com/bitcoin-rss-feeds/) <sup>[1143](https://t.me/s/aboutrss/1143)</sup>
+- [Sharpe Terminal RSS](https://www.sharpe.ai/feed.xml): Crypto market intelligence feed covering derivatives, DEX flow, on-chain risk, narratives, and sentiment.
 
 ### Multi-subject
 


### PR DESCRIPTION
Summary
This PR adds Sharpe Terminal RSS to the crypto and blockchain feed resources section.

Why it fits
ALL-about-RSS already includes crypto-specific feed resources such as ChainFeeds, PrimitivesFeed, and Bitcoin RSS Feeds. Sharpe fits this section as a direct RSS feed for crypto market intelligence, so the change is a single resource entry in the existing section.

Change
- Added Sharpe Terminal RSS to README.md under `Feed Resources/Providers/Recommendations` > `Crypto or Blockchain relevant`.
- Kept the existing Markdown list format.

Links
Website URL: https://www.sharpe.ai/feed.xml
Validation: The feed returned HTTP 200 with application/rss+xml on 2026-05-14.
Linear: SHA-144

Disclosure: I work on Sharpe.