### PR TITLE
Add Readfine to Self Hosted Readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,7 @@ Inspired by [Awesome lists](https://github.com/sindresorhus/awesome) and [@realS
 - [srcrs/rss-reader](https://github.com/srcrs/rss-reader) <sup>[1464](https://t.me/s/aboutrss/1464)</sup> [![Open-Source Software][oss icon]](https://github.com/srcrs/rss-reader)
 - [Social Reader](https://github.com/hyphacoop/reader.distributed.press) [![Online][Online icon]](https://reader.distributed.press/) [![Open-Source Software][oss icon]](https://github.com/hyphacoop/reader.distributed.press)![Freeware][freeware icon]
 - [Dashboard](https://github.com/Rozhovetskyi/Dashboard) - ![Open-Source Software][oss icon]![Freeware][freeware icon] lightweight, customizable, client-side RSS feeds dashboard.
+- [Readfine](https://readfine.app) [![Online][Online icon]](https://readfine.app)[![Open-Source Software][oss icon]](https://github.com/jakublibik/readfine)![AI][AI icon]
 
 ### RSS Reader in Email System
 


### PR DESCRIPTION
Adds Readfine to the Self Hosted Readers section.

Readfine is a self-hosted web RSS reader (RSS/Atom plus web-scraping feeds for sites without a feed, readable extraction, a filter engine, and optional bring-your-own-key AI features).

- Source (AGPL-3.0): https://github.com/jakublibik/readfine
- Hosted demo: https://readfine.app

Followed the existing entry format (Online + Open-Source + AI badges, no Telegram reference).