### PR TITLE
Add What's New to Feed Resources/Providers → Tech or IT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1724,6 +1724,7 @@ So a new user can see something other than a wall of raw XML.  Note that XSLT is
 - [Tech Blogs shared by Emacs China Forum users](https://emacs-china.org/t/elfeed-tech-feeds-rss/17680) <sup>[1071](https://t.me/s/aboutrss/1071)</sup>
 - [Awesome-techCN-feeds](https://github.com/RSS-Renaissance/awesome-techCN-feeds)
 - [~~Refined Blog~~](https://refined.blog/)
+- [What's New](https://whatsnew.fyi/) : follows the changelogs of over a thousand software products. One feed per product, one for everything, with the release notes carried in content:encoded [![Online][Online icon]](https://whatsnew.fyi/)![Freeware][freeware icon]
 
 #### Crypto or Blockchain relevant
 


### PR DESCRIPTION
Adds [What's New](https://whatsnew.fyi/) under **📦 Feed Resources/Providers/Recommendations → Tech or IT**.

It tracks the changelogs of over a thousand software products — open-source projects, games, operating systems, desktop apps — and publishes them as feeds: one per product at `/product/<slug>/feed.xml`, plus a site-wide feed at `/feed.xml`. Release notes travel inside `content:encoded`, so an entry reads in full without leaving the reader, and feeds answer conditional requests with `ETag`/`304`.

Closest existing neighbour is MusicButler in the Entertainment section — same idea, software instead of music.

Free to read, no account. Web only, so it is tagged Online + Freeware.