### PR TITLE
Add Bri to RSS2Podcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -1464,6 +1464,7 @@ Inspired by [Awesome lists](https://github.com/sindresorhus/awesome) and [@realS
 
 ### RSS2Podcast
 
+- [Bri](https://bri.so/): Turn RSS subscriptions into daily podcasts. ![Online][Online icon]![AI][AI icon]
 - [POD GENIE](https://pod-genie.com/) <sup>[1318](https://t.me/s/aboutrss/1318)</sup>
 
 ### RSS2Nostr


### PR DESCRIPTION
## Summary

- Add Bri to the `RSS2Podcast` section.
- Describe Bri as turning RSS subscriptions into daily podcasts.

## Verification

- `curl -fsSIL https://bri.so/` (HTTP 200)
- `git -c core.whitespace=cr-at-eol diff HEAD^ --check`
