### PR TITLE
Add Proofite to Hosted Readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ Inspired by [Awesome lists](https://github.com/sindresorhus/awesome) and [@realS
 - [RSS is Awesome](https://rssisawesome.com/) <sup>[1469](https://t.me/s/aboutrss/1469)</sup> ![Online][Online icon]
 - [Follow](https://follow.is/) <sup>[1478](https://t.me/s/aboutrss/1478), [1489](https://t.me/s/aboutrss/1489)</sup> [![Online][Online icon]](https://app.follow.is/)[![Windows][Windows icon]](https://follow.is/download)[![Mac][Mac icon]](https://follow.is/download)[![Linux][Linux icon]](https://follow.is/download)![AI][AI icon] 
 - [Social Reader](https://github.com/hyphacoop/reader.distributed.press) [![Online][Online icon]](https://reader.distributed.press/) [![Open-Source Software][oss icon]](https://github.com/hyphacoop/reader.distributed.press)![Freeware][freeware icon]
+- [Proofite](https://proofite.com/) [![Online][Online icon]](https://proofite.com/)[![Android][Android icon]](https://play.google.com/store/apps/details?id=com.proofite.app) — AI daily digest of your feeds, newsletters and web searches, also as a podcast; an [MCP server](https://proofite.com/mcp) lets an AI assistant retune what reaches you.
 
 ### Self Hosted Readers
 - [Matcha - Daily RSS Digest](https://github.com/piqoni/matcha) <sup>[1298](https://t.me/s/aboutrss/1298)</sup> [![Open-Source Software][oss icon]](https://github.com/piqoni/matcha)![AI][AI icon]


### PR DESCRIPTION
Adds **Proofite** to *RSS Readers → Hosted Readers*.

It reads your RSS feeds, newsletters (each topic inbox gets its own email address) and daily web searches, and writes them into one AI-written briefing every morning — also available as a private podcast feed, so it plays in any podcast app.

Badges: Online + Android. No iPhone badge on purpose: the iOS app is still in App Store review, I'll add it once it is actually downloadable.

One thing that may interest this list specifically: it exposes an [MCP server](https://proofite.com/mcp), so an AI assistant can read the digest and retune the feed — add or remove feeds, mute topics, change depth. Open source client: https://github.com/hanicker/proofite-mcp (MIT).