### PR TITLE
Add PressPlayed to Hosted Readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ Inspired by [Awesome lists](https://github.com/sindresorhus/awesome) and [@realS
 - [RSS is Awesome](https://rssisawesome.com/) <sup>[1469](https://t.me/s/aboutrss/1469)</sup> ![Online][Online icon]
 - [Follow](https://follow.is/) <sup>[1478](https://t.me/s/aboutrss/1478), [1489](https://t.me/s/aboutrss/1489)</sup> [![Online][Online icon]](https://app.follow.is/)[![Windows][Windows icon]](https://follow.is/download)[![Mac][Mac icon]](https://follow.is/download)[![Linux][Linux icon]](https://follow.is/download)![AI][AI icon] 
 - [Social Reader](https://github.com/hyphacoop/reader.distributed.press) [![Online][Online icon]](https://reader.distributed.press/) [![Open-Source Software][oss icon]](https://github.com/hyphacoop/reader.distributed.press)![Freeware][freeware icon]
+- [PressPlayed](https://pressplayed.com/) [![Online][Online icon]](https://pressplayed.com/) — OPML import and text-to-speech for the text each source provides, auto-advancing through the queue; playback can continue with the screen locked on supported phones.
 
 ### Self Hosted Readers
 - [Matcha - Daily RSS Digest](https://github.com/piqoni/matcha) <sup>[1298](https://t.me/s/aboutrss/1298)</sup> [![Open-Source Software][oss icon]](https://github.com/piqoni/matcha)![AI][AI icon]


### PR DESCRIPTION
Adds PressPlayed to **RSS Readers -> Hosted Readers**.

PressPlayed is a browser-based reader with RSS and OPML import and text-to-speech playback that auto-advances through the queue. It narrates the text each source makes available; it does not summarize articles or bypass paywalls.

Only the Online badge is used. Freeware is omitted because free accounts have a daily narration allowance.

Disclosure: I work on PressPlayed.